### PR TITLE
RegistryHandler update getItemName fix when using with mods

### DIFF
--- a/src/main/java/systems/kinau/fishingbot/modules/fishing/RegistryHandler.java
+++ b/src/main/java/systems/kinau/fishingbot/modules/fishing/RegistryHandler.java
@@ -138,7 +138,11 @@ public class RegistryHandler {
     }
 
     public static String getItemName(int id, int protocol) {
-        return getItemsMap(protocol).get(id);
+        try {
+            return getItemsMap(protocol).get(id);
+        } catch (NullPointerException ignore) {
+            return "Modded Item";
+        }
     }
 
     public static int getEntityType(String entityName, int protocol) {


### PR DESCRIPTION
When using fishing bot with minecraft mod. have Modded Item it's show NullPointerException, now using try catch to show Modded Item